### PR TITLE
Update to rxjs v7

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -22,7 +22,11 @@ module.exports = {
         project: 'tsconfig.spec.json',
         sourceType: 'module'
     },
-    plugins: ['@angular-eslint/eslint-plugin', '@typescript-eslint'],
+    plugins: [
+        '@angular-eslint/eslint-plugin',
+        '@typescript-eslint',
+        'deprecation'
+    ],
     extends: [
         // "eslint:recommended",
         // "plugin:@typescript-eslint/recommended",
@@ -37,6 +41,7 @@ module.exports = {
         '.eslintrc.cjs'
     ],
     rules: {
+        'deprecation/deprecation': 'warn', // or "error" to have stricter rule
         '@angular-eslint/component-class-suffix': 'error',
         '@angular-eslint/component-selector': [
             'error',

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "rollup": "^3.12.0",
     "rollup-plugin-dts": "^5.1.1",
     "rollup-plugin-esbuild": "^5.0.0",
-    "rxjs": "^6.6.7",
+    "rxjs": "^7.8.0",
     "ts-jest": "^29.0.5",
     "ts-node": "^10.9.1",
     "tsc-watch": "^1.1.39",
@@ -77,6 +77,6 @@
   "peerDependencies": {
     "js-csp": "TestJG/js-csp",
     "lodash": "^4.17.4",
-    "rxjs": "^6.2.2"
+    "rxjs": "^7.8.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "esbuild": "^0.17.5",
     "eslint": "^8.33.0",
     "eslint-config-prettier": "^8.6.0",
+    "eslint-plugin-deprecation": "^1.3.3",
     "eslint-plugin-prettier": "^4.2.1",
     "jest": "^29.4.1",
     "js-csp": "github:TestJG/js-csp",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,7 +24,7 @@ specifiers:
   rollup: ^3.12.0
   rollup-plugin-dts: ^5.1.1
   rollup-plugin-esbuild: ^5.0.0
-  rxjs: ^6.6.7
+  rxjs: ^7.8.0
   ts-jest: ^29.0.5
   ts-node: ^10.9.1
   tsc-watch: ^1.1.39
@@ -35,8 +35,8 @@ specifiers:
 devDependencies:
   '@angular-eslint/eslint-plugin': 15.2.0_zkdaqh7it7uc4cvz2haft7rc6u
   '@angular/compiler': 6.0.9
-  '@angular/core': 6.0.9_rxjs@6.6.7+zone.js@0.8.29
-  '@ngrx/store': 6.1.2_elrrlwa5kg3mjz67yxsnybzrba
+  '@angular/core': 6.0.9_rxjs@7.8.0+zone.js@0.8.29
+  '@ngrx/store': 6.1.2_eciiiomv4zfqu36f5fpdgdkh2a
   '@types/jest': 29.4.0
   '@types/lodash': 4.14.191
   '@types/node': 8.10.66
@@ -56,7 +56,7 @@ devDependencies:
   rollup: 3.12.0
   rollup-plugin-dts: 5.1.1_tkwgik6422u3whqaozmypsnvni
   rollup-plugin-esbuild: 5.0.0_xh5ziip2kh75funlguo4husgu4
-  rxjs: 6.6.7
+  rxjs: 7.8.0
   ts-jest: 29.0.5_f3sikf76vpzmjb4j5j2goxj7wi
   ts-node: 10.9.1_xt5hb5pymrmtxudrjo6bjznbby
   tsc-watch: 1.1.39_typescript@4.9.4
@@ -112,13 +112,13 @@ packages:
       tslib: 1.14.1
     dev: true
 
-  /@angular/core/6.0.9_rxjs@6.6.7+zone.js@0.8.29:
+  /@angular/core/6.0.9_rxjs@7.8.0+zone.js@0.8.29:
     resolution: {integrity: sha512-NeEUgymsR/tLvWeEAA4mGEX/S4hHbIo/2uwPGGAQAvzlk+pL7xqPoFSMKeqQahdTnWSmYa/2+X33OdJgXKKXyg==}
     peerDependencies:
       rxjs: ^6.0.0
       zone.js: ~0.8.26
     dependencies:
-      rxjs: 6.6.7
+      rxjs: 7.8.0
       tslib: 1.14.1
       zone.js: 0.8.29
     dev: true
@@ -981,14 +981,14 @@ packages:
       type-detect: 4.0.8
     dev: true
 
-  /@ngrx/store/6.1.2_elrrlwa5kg3mjz67yxsnybzrba:
+  /@ngrx/store/6.1.2_eciiiomv4zfqu36f5fpdgdkh2a:
     resolution: {integrity: sha512-W9MbXrwhIRmN1BlINF9BT+rHR046e1HNk7GqykcDJrK9wW74PJW3aE5iuPb2sTPipBMjPHsXzc73E4U/+OTAyw==}
     peerDependencies:
       '@angular/core': ^6.0.0
       rxjs: ^5.6.0-forward-compat.0 || ^6.0.0
     dependencies:
-      '@angular/core': 6.0.9_rxjs@6.6.7+zone.js@0.8.29
-      rxjs: 6.6.7
+      '@angular/core': 6.0.9_rxjs@7.8.0+zone.js@0.8.29
+      rxjs: 7.8.0
     dev: true
 
   /@nodelib/fs.scandir/2.1.5:
@@ -3339,11 +3339,10 @@ packages:
       queue-microtask: 1.2.3
     dev: true
 
-  /rxjs/6.6.7:
-    resolution: {integrity: sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==}
-    engines: {npm: '>=2.0.0'}
+  /rxjs/7.8.0:
+    resolution: {integrity: sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==}
     dependencies:
-      tslib: 1.14.1
+      tslib: 2.5.0
     dev: true
 
   /semver/6.3.0:
@@ -3635,6 +3634,10 @@ packages:
 
   /tslib/1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
+    dev: true
+
+  /tslib/2.5.0:
+    resolution: {integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==}
     dev: true
 
   /tsutils/3.21.0_typescript@4.9.4:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,7 @@ specifiers:
   esbuild: ^0.17.5
   eslint: ^8.33.0
   eslint-config-prettier: ^8.6.0
+  eslint-plugin-deprecation: ^1.3.3
   eslint-plugin-prettier: ^4.2.1
   jest: ^29.4.1
   js-csp: github:TestJG/js-csp
@@ -47,6 +48,7 @@ devDependencies:
   esbuild: 0.17.5
   eslint: 8.33.0
   eslint-config-prettier: 8.6.0_eslint@8.33.0
+  eslint-plugin-deprecation: 1.3.3_zkdaqh7it7uc4cvz2haft7rc6u
   eslint-plugin-prettier: 4.2.1_jqplj6qf3uqpxpu4gdyhwwasnq
   jest: 29.4.1_kpcmu3f7i7gjcffl5syq5ol7lu
   js-csp: github.com/TestJG/js-csp/efd09c8f3e65fb1534be8a93d94a7afa27bce784
@@ -1182,6 +1184,19 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/experimental-utils/5.50.0_zkdaqh7it7uc4cvz2haft7rc6u:
+    resolution: {integrity: sha512-gZIhzNRivy0RVqcxjKnQ+ipGc0qolilhBeNmvH+Dvu7Vymug+IfiYxTj2zM7mIlHsw6Q5aH7L7WmuTE3tZyzag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@typescript-eslint/utils': 5.50.0_zkdaqh7it7uc4cvz2haft7rc6u
+      eslint: 8.33.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
   /@typescript-eslint/parser/5.49.0_zkdaqh7it7uc4cvz2haft7rc6u:
     resolution: {integrity: sha512-veDlZN9mUhGqU31Qiv2qEp+XrJj5fgZpJ8PW30sHU+j/8/e5ruAhLaVDAeznS7A7i4ucb/s8IozpDtt9NqCkZg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -1218,6 +1233,14 @@ packages:
       '@typescript-eslint/visitor-keys': 5.49.0
     dev: true
 
+  /@typescript-eslint/scope-manager/5.50.0:
+    resolution: {integrity: sha512-rt03kaX+iZrhssaT974BCmoUikYtZI24Vp/kwTSy841XhiYShlqoshRFDvN1FKKvU2S3gK+kcBW1EA7kNUrogg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      '@typescript-eslint/types': 5.50.0
+      '@typescript-eslint/visitor-keys': 5.50.0
+    dev: true
+
   /@typescript-eslint/type-utils/5.49.0_zkdaqh7it7uc4cvz2haft7rc6u:
     resolution: {integrity: sha512-eUgLTYq0tR0FGU5g1YHm4rt5H/+V2IPVkP0cBmbhRyEmyGe4XvJ2YJ6sYTmONfjmdMqyMLad7SB8GvblbeESZA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -1245,6 +1268,11 @@ packages:
 
   /@typescript-eslint/types/5.49.0:
     resolution: {integrity: sha512-7If46kusG+sSnEpu0yOz2xFv5nRz158nzEXnJFCGVEHWnuzolXKwrH5Bsf9zsNlOQkyZuk0BZKKoJQI+1JPBBg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: true
+
+  /@typescript-eslint/types/5.50.0:
+    resolution: {integrity: sha512-atruOuJpir4OtyNdKahiHZobPKFvZnBnfDiyEaBf6d9vy9visE7gDjlmhl+y29uxZ2ZDgvXijcungGFjGGex7w==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
@@ -1280,6 +1308,27 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.49.0
       '@typescript-eslint/visitor-keys': 5.49.0
+      debug: 4.3.4
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.3.8
+      tsutils: 3.21.0_typescript@4.9.4
+      typescript: 4.9.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/typescript-estree/5.50.0_typescript@4.9.4:
+    resolution: {integrity: sha512-Gq4zapso+OtIZlv8YNAStFtT6d05zyVCK7Fx3h5inlLBx2hWuc/0465C2mg/EQDDU2LKe52+/jN4f0g9bd+kow==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 5.50.0
+      '@typescript-eslint/visitor-keys': 5.50.0
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
@@ -1330,6 +1379,26 @@ packages:
       - typescript
     dev: true
 
+  /@typescript-eslint/utils/5.50.0_zkdaqh7it7uc4cvz2haft7rc6u:
+    resolution: {integrity: sha512-v/AnUFImmh8G4PH0NDkf6wA8hujNNcrwtecqW4vtQ1UOSNBaZl49zP1SHoZ/06e+UiwzHpgb5zP5+hwlYYWYAw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@types/json-schema': 7.0.11
+      '@types/semver': 7.3.13
+      '@typescript-eslint/scope-manager': 5.50.0
+      '@typescript-eslint/types': 5.50.0
+      '@typescript-eslint/typescript-estree': 5.50.0_typescript@4.9.4
+      eslint: 8.33.0
+      eslint-scope: 5.1.1
+      eslint-utils: 3.0.0_eslint@8.33.0
+      semver: 7.3.8
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
   /@typescript-eslint/visitor-keys/5.48.1:
     resolution: {integrity: sha512-Ns0XBwmfuX7ZknznfXozgnydyR8F6ev/KEGePP4i74uL3ArsKbEhJ7raeKr1JSa997DBDwol/4a0Y+At82c9dA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -1343,6 +1412,14 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       '@typescript-eslint/types': 5.49.0
+      eslint-visitor-keys: 3.3.0
+    dev: true
+
+  /@typescript-eslint/visitor-keys/5.50.0:
+    resolution: {integrity: sha512-cdMeD9HGu6EXIeGOh2yVW6oGf9wq8asBgZx7nsR/D36gTfQ0odE5kcRYe5M81vjEFAcPeugXrHg78Imu55F6gg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      '@typescript-eslint/types': 5.50.0
       eslint-visitor-keys: 3.3.0
     dev: true
 
@@ -1861,6 +1938,21 @@ packages:
       eslint: '>=7.0.0'
     dependencies:
       eslint: 8.33.0
+    dev: true
+
+  /eslint-plugin-deprecation/1.3.3_zkdaqh7it7uc4cvz2haft7rc6u:
+    resolution: {integrity: sha512-Bbkv6ZN2cCthVXz/oZKPwsSY5S/CbgTLRG4Q2s2gpPpgNsT0uJ0dB5oLNiWzFYY8AgKX4ULxXFG1l/rDav9QFA==}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: ^3.7.5 || ^4.0.0
+    dependencies:
+      '@typescript-eslint/experimental-utils': 5.50.0_zkdaqh7it7uc4cvz2haft7rc6u
+      eslint: 8.33.0
+      tslib: 2.5.0
+      tsutils: 3.21.0_typescript@4.9.4
+      typescript: 4.9.4
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /eslint-plugin-prettier/4.2.1_jqplj6qf3uqpxpu4gdyhwwasnq:

--- a/spec/processes/direct-processor.spec.ts
+++ b/spec/processes/direct-processor.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-len */
 import { merge, of, timer } from 'rxjs';
-import { concat, skip, switchMap } from 'rxjs/operators';
+import { concatWith, skip, switchMap } from 'rxjs/operators';
 import type { TaskItem } from '../../src/processes';
 import {
     fromServiceToDirectProcessor,
@@ -117,9 +117,9 @@ describe('Processes', () => {
 
             describe('When a simple service is given and the processor is finished', () => {
                 const service = {
-                    taskA: () => timer(5).pipe(skip(1), concat(of('A'))),
+                    taskA: () => timer(5).pipe(skip(1), concatWith(of('A'))),
                     taskB: (p: number) =>
-                        timer(p).pipe(skip(1), concat(of('B' + p)))
+                        timer(p).pipe(skip(1), concatWith(of('B' + p)))
                 };
                 const processor = fromServiceToDirectProcessor(service);
 

--- a/spec/processes/logProcessor.spec.ts
+++ b/spec/processes/logProcessor.spec.ts
@@ -1,4 +1,3 @@
-import { ArgumentOutOfRangeError } from 'rxjs';
 import {
     defaultErrorFormatter,
     defaultTaskFormatter,
@@ -61,9 +60,9 @@ describe('Processes', () => {
             expect(
                 defaultErrorFormatter(true)(new Error('Simple error'))
             ).not.toBe('Error: Simple error');
-            expect(
-                defaultErrorFormatter(false)(new ArgumentOutOfRangeError())
-            ).toBe('ArgumentOutOfRangeError: argument out of range');
+            expect(defaultErrorFormatter(false)(new TypeError())).toBe(
+                'TypeError: (no message)'
+            );
         });
     });
 

--- a/spec/processes/makeRunTask.spec.ts
+++ b/spec/processes/makeRunTask.spec.ts
@@ -23,6 +23,7 @@ describe('Processes', () => {
 
             it('calling it with a taskItem without kind should return an observable error', done => {
                 testObs(
+                    // @ts-expect-error
                     runner({ kind: '', payload: 42 }),
                     [],
                     new Error('argument.null.task.kind'),
@@ -32,6 +33,7 @@ describe('Processes', () => {
 
             it('calling it with non-existing kind should return an observable error', done => {
                 testObs(
+                    // @ts-expect-error
                     runner({ kind: 'answer', payload: 42 }),
                     [],
                     new Error('unknown.task:answer'),
@@ -80,6 +82,7 @@ describe('Processes', () => {
 
             it('calling it with a taskItem without kind should return an observable error', done => {
                 testObs(
+                    // @ts-expect-error
                     runner({ kind: '', payload: 42 }),
                     [],
                     new Error('argument.null.task.kind'),
@@ -89,6 +92,7 @@ describe('Processes', () => {
 
             it('calling it with non-existing kind should return an observable error', done => {
                 testObs(
+                    // @ts-expect-error
                     runner({ kind: 'answer', payload: 42 }),
                     [],
                     new Error('unknown.task:answer'),

--- a/spec/processes/makeRunTask.spec.ts
+++ b/spec/processes/makeRunTask.spec.ts
@@ -57,14 +57,14 @@ describe('Processes', () => {
                         setTimeout(() => r(new Error('error')), 10)
                     ),
                 taskObs: (payload: number) =>
-                    Observable.create((obs: Observer<number>) => {
+                    new Observable((obs: Observer<number>) => {
                         setTimeout(() => {
                             obs.next(payload + 30);
                             obs.complete();
                         }, 10);
                     }),
                 taskObsError: (payload: number) =>
-                    Observable.create((obs: Observer<number>) => {
+                    new Observable((obs: Observer<number>) => {
                         setTimeout(() => {
                             obs.error(new Error('error'));
                         }, 10);

--- a/spec/processes/sequential-processor.spec.ts
+++ b/spec/processes/sequential-processor.spec.ts
@@ -81,7 +81,7 @@ describe('Processes', () => {
             });
 
             describe('Given a simple sequential processor', () => {
-                const runner = (item: TaskItem) =>
+                const runner = (item: TaskItem<string, number>) =>
                     timer(item.payload).pipe(map(() => item.payload));
                 const processor = startSequentialProcessor(runner, {
                     maxRetries: 5,
@@ -111,7 +111,7 @@ describe('Processes', () => {
 
             describe('Given a simple sequential processor with a bad behaved task', () => {
                 const runner = makeRunTask({
-                    taskA: (item: TaskItem) =>
+                    taskA: (item: TaskItem<string, number>) =>
                         timer(item.payload).pipe(
                             switchMap(() =>
                                 timer(0, 5).pipe(
@@ -120,7 +120,7 @@ describe('Processes', () => {
                                 )
                             )
                         ),
-                    taskB: (item: TaskItem) =>
+                    taskB: (item: TaskItem<string, number>) =>
                         timer(item.payload).pipe(
                             switchMap(() =>
                                 timer(0, 5).pipe(

--- a/spec/processes/worker-processor.spec.ts
+++ b/spec/processes/worker-processor.spec.ts
@@ -140,7 +140,7 @@ describe('Processes', () => {
                         } catch (e) {
                             done(e);
                         }
-                    }, 100);
+                    }, 500);
                 });
             });
         });

--- a/spec/processes/worker-processor.spec.ts
+++ b/spec/processes/worker-processor.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-len */
 import { ReplaySubject, timer } from 'rxjs';
-import { timeoutWith } from 'rxjs/operators';
+import { timeout } from 'rxjs/operators';
 import type { IProcessor, SimpleWorker } from '../../src/processes';
 import {
     createBackgroundWorker,
@@ -310,9 +310,12 @@ describe('Processes', () => {
                 it("the worker's postMessage should have been called", done => {
                     const theTask = task('inc');
                     const subscription = testObs(
-                        foreWorker
-                            .process(theTask)
-                            .pipe(timeoutWith(20, ['timeout-signal'])),
+                        foreWorker.process(theTask).pipe(
+                            timeout({
+                                each: 20,
+                                with: () => ['timeout-signal']
+                            })
+                        ),
                         [1, 2, 'timeout-signal'],
                         null,
                         done

--- a/spec/utils/csp.spec.ts
+++ b/spec/utils/csp.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-len */
 import { chan, go, promiseChan, put, take } from 'js-csp';
-import { EMPTY, of, throwError, timer } from 'rxjs';
+import { EMPTY, firstValueFrom, of, throwError, timer } from 'rxjs';
 import { map, take as takeObs } from 'rxjs/operators';
 import {
     chanToObservable,
@@ -223,25 +223,23 @@ describe('Utils', () => {
                 expect(promiseToChan).toBeInstanceOf(Function));
 
             it('with a resolving promise it should produce the value in the channel', done => {
-                const prom = timer(10)
-                    .pipe(() => of(10))
-                    .toPromise();
+                const prom = firstValueFrom(timer(10).pipe(() => of(10)));
                 const ch = promiseToChan(prom);
                 testObs(chanToObservable(ch), [10], null, done);
             });
 
             it('with a resolving promise and keepOpen it should produce the value and leave the channel open', done => {
-                const prom = timer(10)
-                    .pipe(() => of(10))
-                    .toPromise();
+                const prom = firstValueFrom(timer(10).pipe(() => of(10)));
                 const ch = promiseToChan(prom, { keepOpen: true });
                 testObs(chanToObservable(ch), [10, 'TIMEOUT'], null, done);
             });
 
             it('with a rejecting promise it should produce the error in the channel', done => {
-                const prom = timer(10)
-                    .pipe(() => throwError(new Error('unexpected')))
-                    .toPromise();
+                const prom = firstValueFrom(
+                    timer(10).pipe(() =>
+                        throwError(() => new Error('unexpected'))
+                    )
+                );
                 const ch = promiseToChan(prom);
                 testObs(
                     chanToObservable(ch),
@@ -252,9 +250,11 @@ describe('Utils', () => {
             });
 
             it('with a rejecting promise and no include errors it should produce an empty channel', done => {
-                const prom = timer(10)
-                    .pipe(() => throwError(new Error('unexpected')))
-                    .toPromise();
+                const prom = firstValueFrom(
+                    timer(10).pipe(() =>
+                        throwError(() => new Error('unexpected'))
+                    )
+                );
                 const ch = promiseToChan(prom, { includeErrors: false });
                 testObs(chanToObservable(ch), [], null, done);
             });
@@ -291,7 +291,9 @@ describe('Utils', () => {
             });
 
             it('with a failing observable it should produce the error in the channel', done => {
-                const obs = timer(10).pipe(() => throwError(new Error('test')));
+                const obs = timer(10).pipe(() =>
+                    throwError(() => new Error('test'))
+                );
                 const ch = firstToChan(obs);
                 testObs(chanToObservable(ch), [new Error('test')], null, done);
             });
@@ -331,7 +333,9 @@ describe('Utils', () => {
             });
 
             it('with a failing observable it should produce the error in the channel', done => {
-                const obs = timer(10).pipe(() => throwError(new Error('test')));
+                const obs = timer(10).pipe(() =>
+                    throwError(() => new Error('test'))
+                );
                 const ch = observableToChan(obs);
                 testObs(chanToObservable(ch), [new Error('test')], null, done);
             });
@@ -377,9 +381,7 @@ describe('Utils', () => {
             });
 
             it('with a promise it should produce the value in the channel', done => {
-                const prom = timer(10)
-                    .pipe(() => of(10))
-                    .toPromise();
+                const prom = firstValueFrom(timer(10).pipe(() => of(10)));
                 const ch = toChan(prom);
                 testObs(chanToObservable(ch), [10], null, done);
             });

--- a/spec/utils/rxtest.ts
+++ b/spec/utils/rxtest.ts
@@ -5,7 +5,7 @@ import {
     materialize,
     take,
     tap,
-    timeoutWith,
+    timeout,
     toArray
 } from 'rxjs/operators';
 import type { LogOpts } from '../../src/utils';
@@ -70,7 +70,7 @@ export const testObsNotifications = <T = any>(
 
     return actual
         .pipe(
-            timeoutWith(doneTimeout, ['TIMEOUT']),
+            timeout({ each: doneTimeout, with: () => ['TIMEOUT'] }),
             materialize(),
             tap(n => log('RECEIVED ', toStr(n))),
             toArray()
@@ -134,7 +134,7 @@ export const testTaskOf =
             concatMap(i => {
                 const elem = args[i];
                 if (i === args.length - 1 && elem instanceof Error) {
-                    return throwError(elem);
+                    return throwError(() => elem);
                 } else {
                     return of(elem);
                 }

--- a/spec/utils/rxutils.spec.ts
+++ b/spec/utils/rxutils.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-len */
 import { of, throwError, timer } from 'rxjs';
-import { concat, concatMap, delay, map, take } from 'rxjs/operators';
+import { concatMap, concatWith, delay, map, take } from 'rxjs/operators';
 import { id } from '../../src/utils/common';
 import {
     firstMap,
@@ -171,7 +171,7 @@ describe('Utils', () => {
 
             it('on an array value should return an observable returning that array as a whole', done => {
                 testObs(
-                    tryTo<string[]>(() => ['many', 'values']),
+                    tryTo(() => ['many', 'values']),
                     [['many', 'values']],
                     null,
                     done
@@ -214,7 +214,7 @@ describe('Utils', () => {
                 const actual = tryTo(() =>
                     of(1, 2, 3).pipe(
                         concatMap(v => of(v).pipe(delay(v))),
-                        concat(throwError(new Error('an error')))
+                        concatWith(throwError(() => new Error('an error')))
                     )
                 );
                 testObs(actual, [1, 2, 3], new Error('an error'), done);
@@ -354,7 +354,7 @@ describe('Utils', () => {
 
             it('should normalize errors', done => {
                 testObs(
-                    firstMap(throwError(4))(id),
+                    firstMap(throwError(() => 4))(id),
                     [],
                     new Error('error.unknown'),
                     done
@@ -387,7 +387,7 @@ describe('Utils', () => {
 
             it('should normalize errors', done => {
                 testObs(
-                    firstSwitchMap(throwError(4))(x => of(x)),
+                    firstSwitchMap(throwError(() => 4))(x => of(x)),
                     [],
                     new Error('error.unknown'),
                     done

--- a/spec/utils/rxutils.spec.ts
+++ b/spec/utils/rxutils.spec.ts
@@ -115,8 +115,8 @@ describe('Utils', () => {
                     true
                 );
             });
-            it('should return true when a custom Subscribable is passed as an argument', () => {
-                expect(isObservableInput({ subscribe: () => {} })).toBe(true);
+            it('should return false when a custom Subscribable is passed as an argument', () => {
+                expect(isObservableInput({ subscribe: () => {} })).toBe(false);
             });
             it('should return true when a custom InterOpObservable is passed as an argument', () => {
                 expect(

--- a/src/processes/direct-processor.ts
+++ b/src/processes/direct-processor.ts
@@ -99,7 +99,7 @@ export function startDirectProcessor<T>(
             try {
                 obs = tryTo(() => runTask(item));
             } catch (error) {
-                obs = throwError(error);
+                obs = throwError(() => error);
             }
 
             return obs;
@@ -143,7 +143,7 @@ export function startDirectProcessor<T>(
 
     const process = (item: TaskItem) => {
         if (!isAlive()) {
-            return throwError(new Error('worker:finishing'));
+            return throwError(() => new Error('worker:finishing'));
         }
         runningCount++;
         const sub = new Subject<any>();

--- a/src/processes/makeRunTask.ts
+++ b/src/processes/makeRunTask.ts
@@ -1,12 +1,27 @@
 import { throwError } from 'rxjs';
-import type { ObsLike } from '../utils/rxutils';
 import { tryTo } from '../utils/rxutils';
 import type { TaskItem } from './processor.interfaces';
 
-export function makeRunTask(runners: {
-    [name: string]: (payload: any) => ObsLike;
-}) {
-    return (task: TaskItem) => {
+type TaskRunner<TPayload, TResult = unknown> = (payload: TPayload) => TResult;
+
+type RunnersDict<TKind extends string, TPayload> = Record<
+    TKind,
+    TaskRunner<TPayload>
+>;
+
+export function makeRunTask<T extends RunnersDict<string, unknown>>(
+    runners: T
+) {
+    return <
+        TKind extends string & keyof T,
+        TPayload extends Parameters<T[TKind]>[0],
+        TResult extends T[TKind] extends TaskRunner<TPayload, infer R>
+            ? R
+            : never,
+        TTask extends TaskItem<TKind, TPayload>
+    >(
+        task: TTask
+    ) => {
         if (!task) {
             return throwError(new Error('argument.null.task'));
         }
@@ -15,12 +30,12 @@ export function makeRunTask(runners: {
             return throwError(new Error('argument.null.task.kind'));
         }
 
-        const runner: (payload: any) => ObsLike = runners[task.kind];
+        const runner = runners[task.kind];
 
         if (!runner) {
             return throwError(new Error(`unknown.task:${task.kind}`));
         }
 
-        return tryTo(() => runner(task.payload));
+        return tryTo(() => runner(task.payload) as TResult);
     };
 }

--- a/src/processes/makeRunTask.ts
+++ b/src/processes/makeRunTask.ts
@@ -23,17 +23,17 @@ export function makeRunTask<T extends RunnersDict<string, unknown>>(
         task: TTask
     ) => {
         if (!task) {
-            return throwError(new Error('argument.null.task'));
+            return throwError(() => new Error('argument.null.task'));
         }
 
         if (!task.kind) {
-            return throwError(new Error('argument.null.task.kind'));
+            return throwError(() => new Error('argument.null.task.kind'));
         }
 
         const runner = runners[task.kind];
 
         if (!runner) {
-            return throwError(new Error(`unknown.task:${task.kind}`));
+            return throwError(() => new Error(`unknown.task:${task.kind}`));
         }
 
         return tryTo(() => runner(task.payload) as TResult);

--- a/src/processes/processor.interfaces.ts
+++ b/src/processes/processor.interfaces.ts
@@ -1,9 +1,9 @@
 import type { Observable } from 'rxjs';
 import { toKVMap, uuid } from '../utils';
 
-export interface TaskItem {
-    kind: string;
-    payload?: any;
+export interface TaskItem<T extends string = string, TPayload = unknown> {
+    kind: T;
+    payload?: TPayload;
     uid?: string;
 }
 
@@ -24,12 +24,16 @@ export interface IProcessor extends IProcessorCore {
     readonly onTaskCompleted$: Observable<TaskItem>;
 }
 
-export const task = (kind: string, payload?: any, uid?: string) =>
-    <TaskItem>{
+export const task = <TKind extends string, TPayload>(
+    kind: TKind,
+    payload?: TPayload,
+    uid?: string
+) =>
+    ({
         kind,
         payload,
         uid: uid || uuid('')
-    };
+    } satisfies TaskItem);
 
 /**
  * Creates an instance of a service, from a given processor and service methods,

--- a/src/processes/router-processor.ts
+++ b/src/processes/router-processor.ts
@@ -32,12 +32,12 @@ export function startRouterProcessor(
     const process = (task: TaskItem) => {
         const pos = task.kind.indexOf(options.routeSeparator);
         if (pos < 0) {
-            return throwError(new Error('argument.invalid.task.kind'));
+            return throwError(() => new Error('argument.invalid.task.kind'));
         }
         const prefix = task.kind.substr(0, pos);
         const route = routes[prefix];
         if (!route) {
-            return throwError(new Error('argument.invalid.task.prefix'));
+            return throwError(() => new Error('argument.invalid.task.prefix'));
         }
         const newKind = task.kind.substr(pos + options.routeSeparator.length);
         const newTask = assign(task, { kind: newKind });
@@ -124,7 +124,7 @@ export function startRouterProxy(
 
     const isAlive = () => processor.isAlive();
 
-    const finish = () => throwError(new Error('invalidop.proxy.finish'));
+    const finish = () => throwError(() => new Error('invalidop.proxy.finish'));
 
     const process = (task: TaskItem) => {
         const newTask = assign(task, {

--- a/src/processes/sequential-processor.ts
+++ b/src/processes/sequential-processor.ts
@@ -1,10 +1,10 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import _ from 'lodash';
+import type { Observable } from 'rxjs';
 import { ReplaySubject, Subject, throwError } from 'rxjs';
 import { tryTo } from '../utils';
 import type { ValueOrFunc } from '../utils/common';
 import { assign, errorToString, getAsValue } from '../utils/common';
-import type { ObsLike } from '../utils/rxutils';
 import { TransientError } from './errors';
 import type { IProcessor, TaskItem } from './processor.interfaces';
 
@@ -64,8 +64,8 @@ export interface SequentialProcessorOptions {
  * @param runTask
  * @param opts
  */
-export function startSequentialProcessor(
-    runTask: (task: TaskItem) => ObsLike<any>,
+export function startSequentialProcessor<T>(
+    runTask: (task: TaskItem) => T,
     options?: Partial<SequentialProcessorOptions>
 ): IProcessor {
     const opts = assign(
@@ -210,7 +210,7 @@ export function startSequentialProcessor(
         }
         work.retries++;
 
-        tryTo(() => runTask(work.item))
+        (tryTo(() => runTask(work.item)) as Observable<T>)
             // .timeout(opts.taskTimeout)
             .subscribe({
                 next: value => {

--- a/src/processes/sequential-processor.ts
+++ b/src/processes/sequential-processor.ts
@@ -260,7 +260,7 @@ export function startSequentialProcessor<T>(
     const process = (item: TaskItem) => {
         if (!_isAlive) {
             log('PROCESS - NOT ALIVE');
-            return throwError(new Error('worker:finishing'));
+            return throwError(() => new Error('worker:finishing'));
         }
 
         const sub = new Subject<any>();

--- a/src/processes/worker-processor.ts
+++ b/src/processes/worker-processor.ts
@@ -138,25 +138,23 @@ export const createForegroundWorker = (opts: {
     };
 
     const process = (task: TaskItem): Observable<any> => {
-        const result = <Observable<any>>Observable.create(
-            (o: Observer<any>) => {
-                const id = uuid();
-                const sub = new Subject<any>();
-                const obs$ = sub.asObservable();
-                observers.set(id, sub);
-                worker.postMessage({ kind: 'process', uid: id, task });
-                const subs = obs$.subscribe({
-                    next: x => o.next(x),
-                    error: e => o.error(e),
-                    complete: () => o.complete()
-                });
+        const result = new Observable((o: Observer<any>) => {
+            const id = uuid();
+            const sub = new Subject<any>();
+            const obs$ = sub.asObservable();
+            observers.set(id, sub);
+            worker.postMessage({ kind: 'process', uid: id, task });
+            const subs = obs$.subscribe({
+                next: x => o.next(x),
+                error: e => o.error(e),
+                complete: () => o.complete()
+            });
 
-                return () => {
-                    subs.unsubscribe();
-                    worker.postMessage({ kind: 'unsubscribe', uid: id });
-                };
-            }
-        );
+            return () => {
+                subs.unsubscribe();
+                worker.postMessage({ kind: 'unsubscribe', uid: id });
+            };
+        });
         return result;
     };
 

--- a/src/utils/csp.ts
+++ b/src/utils/csp.ts
@@ -350,7 +350,7 @@ export const chanToObservable = <T>(
 ): Observable<T> & Logger => {
     const opts = Object.assign({}, options);
     const log = conditionalLog(opts, { prefix: 'OBS_CHAN: ' });
-    const obsResult = <Observable<T>>Observable.create((o: Observer<T>) => {
+    const obsResult = new Observable((o: Observer<T>) => {
         log('Start');
         const cancelCh = promiseChan();
         go(function* () {

--- a/src/utils/rxutils.ts
+++ b/src/utils/rxutils.ts
@@ -57,10 +57,6 @@ export const isObservableInput = <T>(
     if (isPromiseLike(obs)) {
         return true;
     }
-    // Subscribable
-    if (isSubscribable(obs)) {
-        return true;
-    }
     // Array
     if (Array.isArray(obs)) {
         return true;
@@ -81,15 +77,21 @@ export const isObservableInput = <T>(
     return false;
 };
 
+/**
+ * FromObsLike gets a value and returns an observable. If source is an
+ * @ObservableInput - If a string is passed is treated as a value.
+ * it's considered as a single value
+ * @param source Something to turn into an observable
+ * @param treatArraysAsValues @default true
+ * @returns Observable
+ */
 export const fromObsLike = <T>(
     source: ObsLike<T>,
     treatArraysAsValues = true
 ): Observable<T> => {
-    // Can't use isObservableInput because string qualifies as ObservableInput
-    // and current behavior is not to treat it as an observable.
+    // Current behavior is not to treat it as an observable.
     if (
-        isPromiseLike(source) ||
-        isSubscribable(source) ||
+        (isObservableInput(source) && typeof source !== 'string') ||
         (!treatArraysAsValues && source instanceof Array)
     ) {
         return from(source);

--- a/src/utils/rxutils.ts
+++ b/src/utils/rxutils.ts
@@ -96,12 +96,13 @@ export const fromObsLike = <T>(
     source: ObsLike<T>,
     treatArraysAsValues = true
 ): Observable<T> => {
-    // Current behavior is not to treat it as an observable.
+    // Current behavior is not to treat a string as an observable.
     if (
-        (isObservableInput(source) && typeof source !== 'string') ||
-        (!treatArraysAsValues && source instanceof Array)
+        typeof source !== 'string' &&
+        isObservableInput(source) &&
+        (treatArraysAsValues ? !Array.isArray(source) : Array.isArray(source))
     ) {
-        return from(source);
+        return from(source as ObservableInput<T>);
     } else {
         return of(source as T);
     }
@@ -110,7 +111,7 @@ export const fromObsLike = <T>(
 export const tryTo = <T>(
     thunk: (defer: (action: () => void) => void) => ObsLike<T>,
     treatArraysAsValues = true
-): Observable<T> => {
+) => {
     const defers: (() => void)[] = [];
     let finishing = false;
     const defer = (action: () => void) => {

--- a/src/utils/rxutils.ts
+++ b/src/utils/rxutils.ts
@@ -44,7 +44,6 @@ export const isObservableInput = <T>(
     if (!isSomething(obs)) {
         return false;
     }
-
     // Observable
     if (obs instanceof Observable) {
         return true;
@@ -71,6 +70,14 @@ export const isObservableInput = <T>(
     }
     // Iterable
     if (typeof obs[Symbol.iterator] === 'function') {
+        return true;
+    }
+    // AsyncIterable
+    if (typeof obs[Symbol.asyncIterator] === 'function') {
+        return true;
+    }
+    // ReadableStreamLike
+    if (typeof obs['getReader'] === 'function') {
         return true;
     }
 


### PR DESCRIPTION
Introduces a couple of breaking changes.

* RXJS peer version is now `^7.8.0`
* `ObsLike` type is remove in favour `ToObservable`. It didn't reflect actual value (it wouldn't unwrap Observable).